### PR TITLE
Use left join instead of cartesian product

### DIFF
--- a/src/main/java/com/example/demo/FooRepository.java
+++ b/src/main/java/com/example/demo/FooRepository.java
@@ -14,7 +14,7 @@ public interface FooRepository extends JpaRepository<FooEntity, Long> {
      * @param id Long
      * @return Optional<ProjectedFooResult>
      */
-    @Query(nativeQuery = true, value = "SELECT f.name as name, count(b.id) as barCount FROM foo f, bar b WHERE f.id = :id AND b.foo_id = :id")
+    @Query(nativeQuery = true, value = "SELECT f.name as name, count(b.id) as barCount FROM foo f LEFT JOIN bar b ON b.foo_id = f.id WHERE f.id = :id")
     Optional<ProjectedFooResult> getByIdToProjected(Long id);
 }
 


### PR DESCRIPTION
Use left join instead of Cartesian product. It is a bit more readable and it makes a bit easier life of database planner. See https://stackoverflow.com/questions/25271333/sql-speed-increase-left-join-or-cartesian-product-where-clause

PS: Note, that I have not tried this change on my pc, I have done edit through web.